### PR TITLE
Check Download integrity using checksums

### DIFF
--- a/app/models/list_file.rb
+++ b/app/models/list_file.rb
@@ -1,3 +1,5 @@
+require 'download_list_file'
+
 class ListFile < ActiveRecord::Base
 
   STATES = [
@@ -19,18 +21,6 @@ class ListFile < ActiveRecord::Base
   validates :upload_fingerprint, presence: true
 
   def local_file
-    return @local_file if @local_file
-    return false unless upload.present?
-
-    tempfile = Tempfile.new("#{Time.now.utc.to_i}")
-
-    if upload.respond_to?(:s3_object)
-      ok = upload.copy_to_local_file(upload.default_style, tempfile.path)
-      return false if !ok 
-    else
-      FileUtils.copy(upload.path, tempfile.path)
-    end
-      
-    @local_file = tempfile
+    @local_file ||= DownloadListFile.new(self).perform
   end
 end

--- a/app/models/list_file.rb
+++ b/app/models/list_file.rb
@@ -11,11 +11,12 @@ class ListFile < ActiveRecord::Base
   scope :active, -> { where(active: true) }
 
   # Paperclip gem
-  has_attached_file :upload
+  has_attached_file :upload, {preserve_files: "true"}
 
   validates :state, inclusion: STATES.keys.map(&:to_s)
   validates_attachment_content_type :upload, content_type: /\Atext/
   validates_attachment_file_name    :upload, matches: [/txt\Z/]
+  validates :upload_fingerprint, presence: true
 
   def local_file
     return @local_file if @local_file

--- a/db/migrate/20160310160015_add_fingerprint_to_list_file.rb
+++ b/db/migrate/20160310160015_add_fingerprint_to_list_file.rb
@@ -1,0 +1,5 @@
+class AddFingerprintToListFile < ActiveRecord::Migration
+  def change
+    add_column :list_files, :upload_fingerprint, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309051911) do
+ActiveRecord::Schema.define(version: 20160310160015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20160309051911) do
     t.boolean  "active",                        default: false
     t.datetime "created_at",                                    null: false
     t.datetime "updated_at",                                    null: false
+    t.string   "upload_fingerprint"
   end
 
   add_index "list_files", ["state"], name: "index_list_files_on_state", using: :btree

--- a/lib/download_list_file.rb
+++ b/lib/download_list_file.rb
@@ -1,0 +1,31 @@
+require 'file_helper'
+
+class DownloadListFile
+
+  attr_reader :list_file
+
+  def initialize(list_file)
+    @list_file = list_file
+    raise ArgumentError.new "File missing fingerprint, cannot continue" unless @list_file.upload_fingerprint.present? 
+  end
+
+  def perform
+    tempfile = Tempfile.new("#{Time.now.utc.to_i}")
+    upload = list_file.upload
+
+    if upload.respond_to?(:s3_object)
+      ok = upload.copy_to_local_file(upload.default_style, tempfile.path)
+      return false if !ok
+    else
+      FileUtils.copy(upload.path, tempfile.path)
+    end
+    raise "Fingerprint does not match #{list_file.upload_fingerprint}" unless fingerprint(tempfile) == list_file.upload_fingerprint 
+    tempfile
+  end
+
+  private
+
+  def fingerprint(file)
+    FileHelper.fingerprint(file)
+  end
+end

--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -1,0 +1,6 @@
+class FileHelper
+
+  def self.fingerprint(file)
+    Digest::MD5.file(file.path).to_s
+  end
+end

--- a/spec/components/download_list_file_spec.rb
+++ b/spec/components/download_list_file_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+require 'download_list_file'
+
+RSpec.describe DownloadListFile do
+
+  let(:complete_result) { DownloadListFile.new(FactoryGirl.create(:list_file)).perform }
+
+  context 'failure' do
+    it 'fails when fingerprint missing' do
+      list_file = FactoryGirl.create(:list_file)
+      list_file.upload_fingerprint = nil
+      expect { DownloadListFile.new(list_file) }.to raise_error(ArgumentError)
+    end
+
+    it 'fails when S3 download fails' do
+      pending "to do: mock s3 storage environment"
+    end
+
+    it 'fails when downloaded file checksum does not match' do
+      list_file = FactoryGirl.create(:list_file)
+      list_file.upload_fingerprint = '12345'
+      expect { DownloadListFile.new(list_file).perform }.to raise_error(RuntimeError)
+    end
+  end
+
+  it 'returns a Tempfile with path set' do
+    expect(complete_result).to be_instance_of(Tempfile)
+    expect(complete_result.path).not_to be_empty
+    expect(File.exist?(complete_result.path)).to eq(true)
+  end
+end

--- a/spec/factories/list_files.rb
+++ b/spec/factories/list_files.rb
@@ -2,12 +2,6 @@ FactoryGirl.define do
   factory :list_file do
     state "pa"
     upload File.new(File.join(Rails.root, 'spec', 'fixtures', 'dnc_sample.txt'))
-=begin
-    upload_file_name File.join(Rails.root, 'spec', 'fixtures', 'dnc_sample.txt')
-    upload_file_size 120000 
-    upload_content_type "text/plain"
-    upload_updated_at "2016-03-08 21:32:47"
-=end
     active false
   end
 end

--- a/spec/models/list_file_spec.rb
+++ b/spec/models/list_file_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ListFile, type: :model do
   describe '#local_file' do
     it 'returns an existing filepath' do
       list_file = FactoryGirl.create(:list_file)
-      puts File.exist?(list_file.upload.path)
       path = list_file.local_file
       expect(File.exist?(path)).to eq(true)
     end


### PR DESCRIPTION
* Adds fingerprint to ListFile model table
* Checks that downloaded file checksum matches original file checksum
* Separates ListFile#local_file code into DownloadListFile class for single-responsibility
